### PR TITLE
Fix padding size for non-square kernels

### DIFF
--- a/libs/pconv2d_layer.py
+++ b/libs/pconv2d_layer.py
@@ -40,8 +40,8 @@ class PConv2D(Conv2D):
         self.pconv_padding = (
             (int((self.kernel_size[0] - 1) / 2),
              int((self.kernel_size[0] - 1) / 2)),
-            (int((self.kernel_size[0] - 1) / 2),
-             int((self.kernel_size[0] - 1) / 2)),
+            (int((self.kernel_size[1] - 1) / 2),
+             int((self.kernel_size[1] - 1) / 2)),
         )
 
         # Window size - used for normalization


### PR DESCRIPTION
In the base version the padding is calculated assuming a square kernel. This PR fixes it.